### PR TITLE
Add helper to save scraped headlines and test

### DIFF
--- a/src/webscraper.py
+++ b/src/webscraper.py
@@ -1,6 +1,8 @@
 import requests
 from bs4 import BeautifulSoup
 import argparse
+from pathlib import Path
+from urllib.parse import urlparse
 
 def fetch_headlines(url: str, selector: str):
     """
@@ -11,6 +13,17 @@ def fetch_headlines(url: str, selector: str):
     soup = BeautifulSoup(resp.text, 'html.parser')
     elements = soup.select(selector)
     return [el.get_text(strip=True) for el in elements]
+
+
+def save_headlines(url: str, selector: str, results_dir: Path):
+    """Fetch headlines and save them to a domain-named file in results_dir."""
+    headlines = fetch_headlines(url, selector)
+    results_dir = Path(results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    domain = urlparse(url).netloc
+    file_path = results_dir / f"{domain}.txt"
+    file_path.write_text("\n".join(headlines), encoding="utf-8")
+    return file_path
 
 def main():
     parser = argparse.ArgumentParser(description="Simple headline scraper")

--- a/tests/test_webscraper.py
+++ b/tests/test_webscraper.py
@@ -1,5 +1,10 @@
+import shutil
+import sys
+from pathlib import Path
 import pytest
-from src.webscraper import fetch_headlines
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.webscraper import fetch_headlines, save_headlines
 
 HTML = """
 <html><body>
@@ -8,17 +13,34 @@ HTML = """
 </body></html>
 """
 
+
 class DummyResponse:
     def __init__(self, text):
         self.text = text
+
     def raise_for_status(self):
         pass
 
-def monkeypatch_get(url):
-    return DummyResponse(HTML)
 
 def test_fetch_headlines(monkeypatch):
     import requests
+
     monkeypatch.setattr(requests, "get", lambda url: DummyResponse(HTML))
     headlines = fetch_headlines("http://example.com", "h2")
     assert headlines == ["First Headline", "Second Headline"]
+
+
+def test_save_headlines(tmp_path, monkeypatch):
+    import requests
+
+    monkeypatch.setattr(requests, "get", lambda url: DummyResponse(HTML))
+    results_dir = tmp_path / "results"
+    save_headlines("http://example.com", "h2", results_dir)
+
+    output_file = results_dir / "example.com.txt"
+    assert output_file.exists()
+    assert output_file.read_text() == "First Headline\nSecond Headline"
+
+    shutil.rmtree(results_dir)
+    assert not results_dir.exists()
+


### PR DESCRIPTION
## Summary
- Add `save_headlines` utility to store fetched headlines per domain
- Expand tests to verify file output using temporary results directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894688636dc8326b3ea628462b5929a