### PR TITLE
Read URLs from file

### DIFF
--- a/tests/test_webscraper.py
+++ b/tests/test_webscraper.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from src.webscraper import fetch_headlines, save_headlines
+import src.webscraper as webscraper
 
 HTML = """
 <html><body>
@@ -26,7 +26,7 @@ def test_fetch_headlines(monkeypatch):
     import requests
 
     monkeypatch.setattr(requests, "get", lambda url: DummyResponse(HTML))
-    headlines = fetch_headlines("http://example.com", "h2")
+    headlines = webscraper.fetch_headlines("http://example.com", "h2")
     assert headlines == ["First Headline", "Second Headline"]
 
 
@@ -35,11 +35,45 @@ def test_save_headlines(tmp_path, monkeypatch):
 
     monkeypatch.setattr(requests, "get", lambda url: DummyResponse(HTML))
     results_dir = tmp_path / "results"
-    save_headlines("http://example.com", "h2", results_dir)
+    webscraper.save_headlines("http://example.com", "h2", results_dir)
 
     output_file = results_dir / "example.com.txt"
     assert output_file.exists()
     assert output_file.read_text() == "First Headline\nSecond Headline"
+
+    shutil.rmtree(results_dir)
+    assert not results_dir.exists()
+
+
+def test_main_scrapes_urls_from_file(tmp_path, monkeypatch):
+    import requests
+
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text("http://example.com\nhttp://example.org\n", encoding="utf-8")
+    results_dir = tmp_path / "results"
+
+    monkeypatch.setattr(requests, "get", lambda url: DummyResponse(HTML))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "webscraper",
+            "--urls-file",
+            str(urls_file),
+            "--results-dir",
+            str(results_dir),
+        ],
+    )
+
+    webscraper.main()
+
+    output_file1 = results_dir / "example.com.txt"
+    output_file2 = results_dir / "example.org.txt"
+    assert output_file1.exists()
+    assert output_file2.exists()
+    expected = "First Headline\nSecond Headline"
+    assert output_file1.read_text() == expected
+    assert output_file2.read_text() == expected
 
     shutil.rmtree(results_dir)
     assert not results_dir.exists()


### PR DESCRIPTION
## Summary
- allow scraping multiple URLs by reading them from `input/urls.txt` without passing a URL argument
- add helper to read URLs and iterate through them, saving each domain's headlines
- extend tests to cover new multi-URL scraping workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68946f6d71b08326b43900a277417122