### PR TITLE
Download and store favicons for each URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 *.py[cod]
 venv/
 results/
+favicons/
 .env

--- a/src/webscraper.py
+++ b/src/webscraper.py
@@ -27,6 +27,19 @@ def save_headlines(url: str, selector: str, results_dir: Path):
     return file_path
 
 
+def download_favicon(url: str, favicons_dir: Path):
+    """Download the favicon for the given URL into favicons_dir."""
+    favicons_dir = Path(favicons_dir)
+    favicons_dir.mkdir(parents=True, exist_ok=True)
+    parsed = urlparse(url)
+    favicon_url = f"{parsed.scheme}://{parsed.netloc}/favicon.ico"
+    resp = requests.get(favicon_url)
+    resp.raise_for_status()
+    file_path = favicons_dir / f"{parsed.netloc}.ico"
+    file_path.write_bytes(resp.content)
+    return file_path
+
+
 def read_urls(file_path: Path):
     """Return a list of URLs read from a text file, ignoring blank lines."""
     file_path = Path(file_path)
@@ -40,6 +53,7 @@ def read_urls(file_path: Path):
 BASE_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_URLS_FILE = BASE_DIR / "input" / "urls.txt"
 DEFAULT_RESULTS_DIR = BASE_DIR / "results"
+DEFAULT_FAVICONS_DIR = BASE_DIR / "favicons"
 
 
 def main():
@@ -61,6 +75,12 @@ def main():
         type=Path,
         help="Directory to store results (default: results)",
     )
+    parser.add_argument(
+        "--favicons-dir",
+        default=DEFAULT_FAVICONS_DIR,
+        type=Path,
+        help="Directory to store favicons (default: favicons)",
+    )
     args = parser.parse_args()
 
     try:
@@ -73,6 +93,8 @@ def main():
         try:
             output_file = save_headlines(url, args.selector, args.results_dir)
             print(f"Saved headlines from {url} to {output_file}")
+            favicon_file = download_favicon(url, args.favicons_dir)
+            print(f"Saved favicon from {url} to {favicon_file}")
         except Exception as e:
             print(f"Error scraping {url}: {e}")
 

--- a/tests/test_webscraper.py
+++ b/tests/test_webscraper.py
@@ -15,8 +15,9 @@ HTML = """
 
 
 class DummyResponse:
-    def __init__(self, text):
+    def __init__(self, text="", content=b""):
         self.text = text
+        self.content = content
 
     def raise_for_status(self):
         pass
@@ -45,14 +46,36 @@ def test_save_headlines(tmp_path, monkeypatch):
     assert not results_dir.exists()
 
 
+def test_download_favicon(tmp_path, monkeypatch):
+    import requests
+
+    favicons_dir = tmp_path / "favicons"
+
+    def fake_get(url):
+        return DummyResponse(content=b"ICO")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    file_path = webscraper.download_favicon("http://example.com", favicons_dir)
+
+    assert file_path.exists()
+    assert file_path.read_bytes() == b"ICO"
+
+
 def test_main_scrapes_urls_from_file(tmp_path, monkeypatch):
     import requests
 
     urls_file = tmp_path / "urls.txt"
     urls_file.write_text("http://example.com\nhttp://example.org\n", encoding="utf-8")
     results_dir = tmp_path / "results"
+    favicons_dir = tmp_path / "favicons"
 
-    monkeypatch.setattr(requests, "get", lambda url: DummyResponse(HTML))
+    def fake_get(url):
+        if url.endswith("favicon.ico"):
+            return DummyResponse(content=b"ICO")
+        return DummyResponse(HTML)
+
+    monkeypatch.setattr(requests, "get", fake_get)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -62,6 +85,8 @@ def test_main_scrapes_urls_from_file(tmp_path, monkeypatch):
             str(urls_file),
             "--results-dir",
             str(results_dir),
+            "--favicons-dir",
+            str(favicons_dir),
         ],
     )
 
@@ -75,6 +100,15 @@ def test_main_scrapes_urls_from_file(tmp_path, monkeypatch):
     assert output_file1.read_text() == expected
     assert output_file2.read_text() == expected
 
+    favicon1 = favicons_dir / "example.com.ico"
+    favicon2 = favicons_dir / "example.org.ico"
+    assert favicon1.exists()
+    assert favicon2.exists()
+    assert favicon1.read_bytes() == b"ICO"
+    assert favicon2.read_bytes() == b"ICO"
+
     shutil.rmtree(results_dir)
+    shutil.rmtree(favicons_dir)
     assert not results_dir.exists()
+    assert not favicons_dir.exists()
 


### PR DESCRIPTION
## Summary
- add `download_favicon` helper and CLI option to save each site's favicon
- ignore generated `favicons/` directory
- test favicon downloading and integration with main script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894718e5e00832687bf183eca0e8775