### PR TITLE
Document subpage title scraping output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@ git clone git@github.com:your-username/my-webscraper.git
 cd my-webscraper
 python3 -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
+```
+
+## Collecting subpages and titles
+
+The scraper can crawl each provided URL, follow links to its subpages, and
+record the `<title>` of every subpage. The collected data is written to
+`results/subpages_<domein>.txt`, where `<domein>` is the host name of the
+original URL. Each line of the file contains a subpage URL followed by its
+title.
+
+### CLI-voorbeeld
+
+```bash
+python src/webscraper.py --collect-subpages https://example.com
+```
+


### PR DESCRIPTION
## Summary
- explain how subpages and their titles are saved under `results/subpages_<domein>.txt`
- add CLI example for collecting subpage titles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894bd6e6df883268985f7a3cc144afe