### PR TITLE
Handle missing favicon gracefully

### DIFF
--- a/src/webscraper.py
+++ b/src/webscraper.py
@@ -133,12 +133,17 @@ def main():
         try:
             output_file = save_headlines(url, args.selector, args.results_dir)
             print(f"Saved headlines from {url} to {output_file}")
-            favicon_file = download_favicon(url, args.favicons_dir)
-            print(f"Saved favicon from {url} to {favicon_file}")
             subpages_file = save_subpages(url, args.results_dir)
             print(f"Saved subpages from {url} to {subpages_file}")
         except Exception as e:
             print(f"Error scraping {url}: {e}")
+            continue
+
+        try:
+            favicon_file = download_favicon(url, args.favicons_dir)
+            print(f"Saved favicon from {url} to {favicon_file}")
+        except Exception as e:
+            print(f"Error downloading favicon from {url}: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Save headlines and subpages even when favicon retrieval fails
- Test that scraping results persist when favicon is unavailable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6894c11985e48326ad4389537e2250a4